### PR TITLE
Add school name editing for cb admin

### DIFF
--- a/src/services/schoolService.js
+++ b/src/services/schoolService.js
@@ -18,3 +18,29 @@ export const getClassInstances = async (schoolCode) => {
     throw error;
   }
 };
+
+/**
+ * Update a school's display name
+ * @param {string|number} schoolId - Primary key of the school row
+ * @param {string} newSchoolName - New school name to set
+ * @returns {Promise<object>} Updated school record
+ */
+export const updateSchoolName = async (schoolId, newSchoolName) => {
+  if (!schoolId) throw new Error('schoolId is required');
+  const trimmedName = (newSchoolName || '').trim();
+  if (!trimmedName) throw new Error('School name cannot be empty');
+
+  try {
+    const { data, error } = await supabase
+      .from('schools')
+      .update({ school_name: trimmedName })
+      .eq('id', schoolId)
+      .select('*')
+      .single();
+
+    if (error) throw error;
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
Add an option for CB admins to edit school names directly from the dashboard.

This PR introduces a new `updateSchoolName` service function and integrates an edit modal into the CB Admin Dashboard, allowing administrators to modify school names via a dedicated action button in the schools table.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ea2f675-4424-4609-a31d-40433338b411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ea2f675-4424-4609-a31d-40433338b411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

